### PR TITLE
Add `#[HandlerFor]` Attribute

### DIFF
--- a/src/HandlerFor.php
+++ b/src/HandlerFor.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brammm\Tactishun;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class HandlerFor
+{
+    public final array $commands;
+
+    /**
+     * @param class-string $commands
+     */
+    public function __construct(string ...$commands)
+    {
+        $this->commands = $commands;
+    }
+}

--- a/src/HandlerForResolver.php
+++ b/src/HandlerForResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brammm\Tactishun;
+
+use Brammm\Tactishun\Resolver\CommandHandlerResolver;
+use Brammm\Tactishun\Resolver\HandlerNotFound;
+use ReflectionClass;
+use ReflectionException;
+
+final class HandlerForResolver implements CommandHandlerResolver
+{
+
+    private array $commandHandlers;
+
+    /**
+     * @param class-string<CommandHandler>[] $commandHandlers
+     */
+    public function __construct(string ...$commandHandlers) {
+        $this->commandHandlers = $commandHandlers;
+    }
+
+    public function resolve(object $command) : string
+    {
+        $bestMatch = null;
+        foreach ($this->commandHandlers as $i => $handlerClassname) {
+            try {
+                foreach (new ReflectionClass($handlerClassname)->getAttributes(HandlerFor::class) as $handlerFor) {
+                    if (in_array($command, $handlerFor->newInstance()->commands)) {
+                        return $handlerClassname;
+                    }
+
+                    foreach ($handlerFor->newInstance()->commands as $handlableCommand) {
+                        if ($command === $handlableCommand) {
+                          return $handlerClassname;
+                        }
+                        if (empty($bestMatch) && is_a($command, $handlableCommand, true)) {
+                          $bestMatch = $handlerClassname;
+                        }
+                    }
+                }
+            } catch (ReflectionException $e) {
+                // don't try this one again next time
+                unset($this->commandHandlers[$i]);
+            }
+        }
+
+        return $bestMatch ?? throw new HandlerNotFound($command::class);
+    }
+}

--- a/src/Resolver/HandlerForResolver.php
+++ b/src/Resolver/HandlerForResolver.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Brammm\Tactishun;
+namespace Brammm\Tactishun\Resolver;
 
+use Brammm\Tactishun\HandlerFor;
 use Brammm\Tactishun\Resolver\CommandHandlerResolver;
 use Brammm\Tactishun\Resolver\HandlerNotFound;
 use ReflectionClass;

--- a/src/Resolver/ResolverAggregate.php
+++ b/src/Resolver/ResolverAggregate.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brammm\Tactishun\Resolver;
+
+use Brammm\Tactishun\Resolver\CommandHandlerResolver;
+use Brammm\Tactishun\Resolver\HandlerNotFound;
+
+final class ResolverAggregate implements CommandHandlerResolver
+{
+
+    private array $resolvers;
+
+    /**
+     * @param CommandHandlerResolver[] $resolvers
+     */
+    public function __construct(CommandHandlerResolver ...$resolvers)
+    {
+        $this->resolvers = $resolvers;
+    }
+
+    public function resolve(object $command) : string
+    {
+        foreach ($this->resolvers as $resolver) {
+            try {
+                return $resolver->resolve($command);
+            } catch (HandlerNotFound) {
+                // continue
+            }
+        }
+        throw new HandlerNotFound($command::class);
+    }
+}

--- a/tests/Resolver/HandlerForResolverTest.php
+++ b/tests/Resolver/HandlerForResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brammm\Tactishun\Tests\Resolver;
+
+use Brammm\Tactishun\HandlerForResolver;
+use Brammm\Tactishun\Resolver\HandlerNotFound;
+use Brammm\Tactishun\Tests\TestImplementations\Command;
+use Brammm\Tactishun\Tests\TestImplementations\CommandHandler;
+use Brammm\Tactishun\Tests\TestImplementations\CommandHandlerFor;
+use Brammm\Tactishun\Tests\TestImplementations\CommandWithoutAttribute;
+use PHPUnit\Framework\TestCase;
+
+final class HandlerForResolverTest extends TestCase
+{
+    public function testItResolvesRegisteredCommand(): void
+    {
+        $resolver = new HandlerForResolver(CommandHandlerFor::class);
+        $handler  = $resolver->resolve(new CommandWithoutAttribute('Jerry'));
+
+        self::assertEquals(CommandHandlerFor::class, $handler);
+    }
+
+    public function testItThrowsExceptionIfCommandNotRegistered(): void
+    {
+        $resolver = new HandlerForResolver(CommandHandlerFor::class);
+
+        $this->expectException(HandlerNotFound::class);
+        $resolver->resolve(new Command('Jerry'));
+    }
+}

--- a/tests/Resolver/ResolverAggregateTest.php
+++ b/tests/Resolver/ResolverAggregateTest.php
@@ -4,21 +4,28 @@ declare(strict_types=1);
 
 namespace Brammm\Tactishun\Tests\Resolver;
 
+use Brammm\Tactishun\Resolver\HandledByCommandHandlerResolver;
 use Brammm\Tactishun\Resolver\HandlerForResolver;
 use Brammm\Tactishun\Resolver\HandlerNotFound;
+use Brammm\Tactishun\Resolver\ResolverAggregate;
 use Brammm\Tactishun\Tests\TestImplementations\Command;
+use Brammm\Tactishun\Tests\TestImplementations\CommandHandler;
 use Brammm\Tactishun\Tests\TestImplementations\CommandHandlerFor;
 use Brammm\Tactishun\Tests\TestImplementations\CommandWithoutAttribute;
 use PHPUnit\Framework\TestCase;
 
-final class HandlerForResolverTest extends TestCase
+final class ResolverAggregatetest extends TestCase
 {
     public function testItResolvesRegisteredCommand(): void
     {
-        $resolver = new HandlerForResolver(CommandHandlerFor::class);
-        $handler  = $resolver->resolve(new CommandWithoutAttribute('Jerry'));
+        $resolverA = new HandledByCommandHandlerResolver();
+        $resolverB = new HandlerForResolver(CommandHandlerFor::class);
+        $aggregateResolver = new ResolverAggregate($resolverA, $resolverB);
+        $handlerA = $aggregateResolver->resolve(new Command('John'));
+        $handlerB = $aggregateResolver->resolve(new CommandWithoutAttribute('Jerry'));
 
-        self::assertEquals(CommandHandlerFor::class, $handler);
+        self::assertEquals(CommandHandler::class, $handlerA);
+        self::assertEquals(CommandHandlerFor::class, $handlerB);
     }
 
     public function testItThrowsExceptionIfCommandNotRegistered(): void

--- a/tests/TestImplementations/CommandHandlerFor.php
+++ b/tests/TestImplementations/CommandHandlerFor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brammm\Tactishun\Tests\TestImplementations;
+
+use Brammm\Tactishun\CommandHandler as CommandHandlerInterface;
+use Brammm\Tactishun\HandlerFor;
+
+/**
+ * @implements CommandHandlerInterface<Command>
+ * @implements CommandHandlerInterface<CommandWithoutAttribute>
+ */
+#[HandlerFor(CommandWithoutAttribute::class)]
+final class CommandHandlerFor implements CommandHandlerInterface
+{
+    public string|null $name = null;
+
+    public function handle(object $command): void
+    {
+        $this->name = $command->name;
+    }
+}

--- a/tests/TestImplementations/CommandHandlerFor.php
+++ b/tests/TestImplementations/CommandHandlerFor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Brammm\Tactishun\Tests\TestImplementations;
 
-use Brammm\Tactishun\CommandHandler as CommandHandlerInterface;
+use Brammm\Tactishun\CommandHandler\CommandHandler as CommandHandlerInterface;
 use Brammm\Tactishun\HandlerFor;
 
 /**


### PR DESCRIPTION
Supports declaring a resolver that registers command handlers and explicitly mapping the commands each handles.

This is the opposite approach to using the `#[HandledBy]` attribute, which allows commands to specify their handler.
Usage is like:
```php
<?php

use Brammm\Tactishun\CommandBus;
use Brammm\Tactishun\HandlerFor;
use Brammm\Tactishun\HandlerForResolver;
use Brammm\Tactishun\CommandHandler;

// 1. Create your command
final readonly class SendWelcomeMail {
    public function __construct( public UserId $userId ) {}
}

// 2. Implement the handler
/** @implements CommandHandler<SendWelcomeMail> */
#[HandlerFor(SendWelcomeEmail::class)]
final class SendWelcomeMailHandler implements CommandHandler {
    public function handle(object $command): void {
        // Fetch user from $command->userId and send welcome email
    }
}

// 3. Set up the command bus
$container = new Container(); // Any PSR-11 compatible container
$resolver = new HandlerForResolver(SendWelcomeMailHandler::class);
$commandBus = new CommandBus($container, $resolver);

// 4. Dispatch commands
$commandBus->handle(new SendWelcomeMail($user->id));
```